### PR TITLE
(Dockerfile) Change tuna mirror to llvm.org source

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,9 +31,9 @@ EOF
 RUN apt update && \
   DEBIAN_FRONTEND="noninteractive" apt install -y wget gnupg && \
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-  echo "deb http://mirrors.tuna.tsinghua.edu.cn/llvm-apt/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list && \
-  echo "deb http://mirrors.tuna.tsinghua.edu.cn/llvm-apt/focal/ llvm-toolchain-focal-12 main" >> /etc/apt/sources.list && \
-  echo "deb http://mirrors.tuna.tsinghua.edu.cn/llvm-apt/focal/ llvm-toolchain-focal-13 main" >> /etc/apt/sources.list
+  echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list && \
+  echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main" >> /etc/apt/sources.list && \
+  echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" >> /etc/apt/sources.list
 
 # install necessary packages
 RUN apt update && DEBIAN_FRONTEND="noninteractive" apt install -y \


### PR DESCRIPTION
[#4 ](https://github.com/pku-minic/compiler-dev/issues/4)

由于不清楚更改llvm版本对项目的影响，暂时更换到llvm官方apt源用于下载。

log如下：
[make.log](https://github.com/user-attachments/files/18082742/make.log)