### PR TITLE
Add clangd support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN apt update && DEBIAN_FRONTEND="noninteractive" apt install -y \
   git flex bison python3 \
   make cmake \
   qemu-user-static \
-  clang-21 lldb-21 lld-21
+  clang-21 clangd-21 lldb-21 lld-21
 
 # setup LLVM toolchain
 WORKDIR /root

--- a/docker/update-alternatives-clang.sh
+++ b/docker/update-alternatives-clang.sh
@@ -40,6 +40,7 @@ function register_clang_version {
     --slave   /usr/bin/clang-cl              clang-cl              /usr/bin/clang-cl-${version} \
     --slave   /usr/bin/clang-cpp             clang-cpp             /usr/bin/clang-cpp-${version} \
     --slave   /usr/bin/clang-format          clang-format          /usr/bin/clang-format-${version} \
+    --slave   /usr/bin/clangd                clangd                /usr/bin/clangd-${version}  \
     --slave   /usr/bin/clang-format-diff     clang-format-diff     /usr/bin/clang-format-diff-${version} \
     --slave   /usr/bin/clang-import-test     clang-import-test     /usr/bin/clang-import-test-${version} \
     --slave   /usr/bin/clang-include-fixer   clang-include-fixer   /usr/bin/clang-include-fixer-${version} \


### PR DESCRIPTION
This pull request updates the Docker environment and the alternatives configuration script to ensure that `clangd` is properly installed and managed alongside other LLVM tools. The main focus is on adding support for the `clangd` language server.

**Motivation:**

* I encountered a problem with clangd and clang version alignment when using a cpp module. I eventually solved it using the devcontainer plugin, but I hope that upstream support for clangd can be added to avoid other potential problems.